### PR TITLE
Feature/multiple same argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: php
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
   - hhvm
 
 # http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
@@ -12,8 +14,8 @@ matrix:
     - php: hhvm
 
 before_script:
-  - make composer
+  - make
 
 script:
-    - make standards
+    - make qa
     - make test

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,21 @@
-all: clean composer lint phploc phpmd phpcs phpcpd phpunit
+### Variables
 
-clean:
-	rm -rf vendor
+# Applications
+COMPOSER ?= /usr/bin/env composer
 
-composer:
-	/usr/bin/env composer install --no-progress --prefer-source
+### Helpers
+all: clean depend
+
+.PHONY: all
+
+### Dependencies
+depend:
+	${COMPOSER} install --no-progress --prefer-source
+
+.PHONY: depend
+
+### QA
+qa: lint phpmd phpcs phpcpd
 
 lint:
 	find ./src -name "*.php" -exec /usr/bin/env php -l {} \; | grep "Parse error" > /dev/null && exit 1 || exit 0
@@ -22,7 +33,16 @@ phpcs:
 phpcpd:
 	vendor/bin/phpcpd src/
 
+.PHONY: qa lint phploc phpmd phpcs phpcpd
+
+### Testing
 test:
 	vendor/bin/phpunit -v --colors --coverage-text
 
-standards: phpmd phpcs phpcpd
+.PHONY: test
+
+### Cleaning
+clean:
+	rm -rf vendor
+
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ If you want multiple arguments of the same name, then `$value` can be an array, 
 ```php
 use AdamBrett\ShellWrapper\Command\Argument;
 
-$shell->addArgument(new Argument('--exclude', ['.git*', 'cache'])); 
+$shell->addArgument(new Argument('exclude', ['.git*', 'cache'])); 
 ```
 
 Which would result in the following:

--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ $shell->addArgument(new Argument($name, $value));
 
 `$value` will be automatically escaped behind the scenes, but `$name` will not, so make sure you never have user input in `$name`, or if you do, escape it yourself.
 
+If you want multiple arguments of the same name, then `$value` can be an array, like so:
+
+```php
+use AdamBrett\ShellWrapper\Command\Argument;
+
+$shell->addArgument(new Argument('--exclude', ['.git*', 'cache'])); 
+```
+
+Which would result in the following:
+
+```bash
+somecommand --exclude '.git*' --exclude 'cache'
+```
+
 Flags
 -----
 

--- a/src/Command/Value.php
+++ b/src/Command/Value.php
@@ -5,24 +5,37 @@ namespace AdamBrett\ShellWrapper\Command;
 abstract class Value
 {
     protected $name;
-    protected $value;
+    protected $values;
 
-    public function __construct($name, $value = null)
+    public function __construct($name, $values = null)
     {
         $this->name = $name;
-        $this->value = $value;
+
+        if (!is_array($values) && $values !== null) {
+            $values = array($values);
+        }
+
+        $this->values = $values;
     }
 
     public function __toString()
     {
-        if ($this->value === null) {
+        if ($this->values === null) {
             return sprintf('%s%s', static::PREFIX, $this->name);
         }
-        return sprintf('%s%s %s', static::PREFIX, $this->name, escapeshellarg($this->value));
+
+        return $this->getValuesAsString();
     }
 
     public function getName()
     {
         return $this->name;
+    }
+
+    protected function getValuesAsString()
+    {
+        $values = array_map('escapeshellarg', $this->values);
+        $prefix = sprintf('%s%s ', static::PREFIX, $this->name);
+        return $prefix . join(" ${prefix}", $values);
     }
 }

--- a/tests/unit-tests/Command/ArgumentTest.php
+++ b/tests/unit-tests/Command/ArgumentTest.php
@@ -38,7 +38,7 @@ class ArgumentTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleOfSameName()
     {
-        $param = new Argument('test', ['value1', 'value2']);
+        $param = new Argument('test', array('value1', 'value2'));
         $this->assertEquals("--test 'value1' --test 'value2'", (string) $param, 'Mutiple params should be allowed');
     }
 }

--- a/tests/unit-tests/Command/ArgumentTest.php
+++ b/tests/unit-tests/Command/ArgumentTest.php
@@ -39,6 +39,6 @@ class ArgumentTest extends \PHPUnit_Framework_TestCase
     public function testMultipleOfSameName()
     {
         $param = new Argument('test', array('value1', 'value2'));
-        $this->assertEquals("--test 'value1' --test 'value2'", (string) $param, 'Mutiple params should be allowed');
+        $this->assertEquals("--test 'value1' --test 'value2'", (string) $param, 'Mutiple arguments should be allowed');
     }
 }

--- a/tests/unit-tests/Command/ArgumentTest.php
+++ b/tests/unit-tests/Command/ArgumentTest.php
@@ -35,4 +35,10 @@ class ArgumentTest extends \PHPUnit_Framework_TestCase
         $argument = new Argument('test');
         $this->assertEquals('--test', (string) $argument, 'Valueless arguments should be allowed');
     }
+
+    public function testMultipleOfSameName()
+    {
+        $param = new Argument('test', ['value1', 'value2']);
+        $this->assertEquals("--test 'value1' --test 'value2'", (string) $param, 'Mutiple params should be allowed');
+    }
 }

--- a/tests/unit-tests/Command/FlagTest.php
+++ b/tests/unit-tests/Command/FlagTest.php
@@ -35,4 +35,10 @@ class FlagTest extends \PHPUnit_Framework_TestCase
         $argument = new Flag('test');
         $this->assertEquals('-test', (string) $argument, 'Valueless arguments should be allowed');
     }
+
+    public function testMultipleOfSameName()
+    {
+        $param = new Flag('test', array('value1', 'value2'));
+        $this->assertEquals("-test 'value1' -test 'value2'", (string) $param, 'Mutiple flags should be allowed');
+    }
 }


### PR DESCRIPTION
Syntax to allow multiple arguments of the same name.

Rather than removing the name/key association to allow you to add multiple arguments (which would likely require some sort of search/remove functionality too), I decided to just allow `$value` to be an array when adding any of the `AdamBrett\ShellWrapper\Command\Value` subtypes (`Argument` and `Flag`).

This is in reference to #8 
