### PR TITLE
Sanitize dangerous SubCommands and Argument names

### DIFF
--- a/src/Command/SubCommand.php
+++ b/src/Command/SubCommand.php
@@ -6,6 +6,21 @@ class SubCommand extends AbstractCommand
 {
     public function __toString()
     {
-        return $this->command;
+        return $this->escape($this->command);
+    }
+
+    protected function escape($cmd)
+    {
+        // strip control characters:
+        if (function_exists('mb_detect_encoding') && mb_detect_encoding($cmd, 'UTF-8', true)) {
+            $cmd = preg_replace('~\p{C}|\p{Zl}|\p{Zp}~u', '', $cmd);
+        } else {
+            $cmd = preg_replace('~[[:cntrl:]\x81-\xFF]~', '', $cmd);
+        }
+
+        // escape some things to make sure that the SubCommand stays one argument on the shell:
+        $cmd = preg_replace('~[^A-Za-z0-9_./{}*?,-]~', '\\' . '\\' . '\\0', $cmd);
+
+        return $cmd;
     }
 }

--- a/src/Command/Value.php
+++ b/src/Command/Value.php
@@ -21,7 +21,7 @@ abstract class Value
     public function __toString()
     {
         if ($this->values === null) {
-            return sprintf('%s%s', static::PREFIX, $this->name);
+            return sprintf('%s%s', static::PREFIX, $this->sanitizeName($this->name));
         }
 
         return $this->getValuesAsString();
@@ -35,7 +35,22 @@ abstract class Value
     protected function getValuesAsString()
     {
         $values = array_map('escapeshellarg', $this->values);
-        $prefix = sprintf('%s%s ', static::PREFIX, $this->name);
+        $prefix = sprintf('%s%s ', static::PREFIX, $this->sanitizeName($this->name));
         return $prefix . join(" ${prefix}", $values);
+    }
+
+    protected function sanitizeName($name)
+    {
+        // strip control characters:
+        if (function_exists('mb_detect_encoding') && mb_detect_encoding($name, 'UTF-8', true)) {
+            $name = preg_replace('~\p{C}|\p{Zl}|\p{Zp}~u', '', $name);
+        } else {
+            $name = preg_replace('~[[:cntrl:]\x81-\xFF]~', '', $name);
+        }
+
+        // escape some things to make sure that the name stays one argument on the shell:
+        $name = preg_replace('~[^A-Za-z0-9_./-]~', '\\' . '\\' . '\\0', $name);
+
+        return $name;
     }
 }

--- a/tests/unit-tests/Command/ArgumentTest.php
+++ b/tests/unit-tests/Command/ArgumentTest.php
@@ -36,6 +36,34 @@ class ArgumentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('--test', (string) $argument, 'Valueless arguments should be allowed');
     }
 
+    public function testArgumentNameEscape()
+    {
+        $argument = new Argument('test && rm *', 'a b');
+        $this->assertEquals('--test\ \&\&\ rm\ \* \'a b\'', (string) $argument, 'Dangerous names should be sanitized');
+    }
+
+    public function testArgumentNameSanitizeControlCharacters()
+    {
+        $argument = new Argument("test\r\n");
+        $this->assertEquals('--test', (string) $argument, 'Control characters should be stripped from names');
+    }
+
+    public function testArgumentNameSanitizeControlCharactersUtf8()
+    {
+        $argument = new Argument("test\r\n\xE2\x80\xA8-\xD8\x9C2");
+        $this->assertEquals('--test-2', (string) $argument, 'Control characters should be stripped from names (UTF-8)');
+    }
+
+    public function testArgumentNameSanitizeNonAsciiNonUtf8()
+    {
+        $argument = new Argument("t\xC4st\r\n");
+        $this->assertEquals(
+            '--tst',
+            (string) $argument,
+            'From non-UTF-8 name strings, all non-ascii characters should be stripped'
+        );
+    }
+
     public function testMultipleOfSameName()
     {
         $param = new Argument('test', array('value1', 'value2'));

--- a/tests/unit-tests/Command/FlagTest.php
+++ b/tests/unit-tests/Command/FlagTest.php
@@ -30,6 +30,38 @@ class FlagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $argument->getName(), 'Flag name should be returned');
     }
 
+    public function testFlagNameEscape()
+    {
+        $argument = new Flag('test && rm *', 'a b');
+        $this->assertEquals('-test\ \&\&\ rm\ \* \'a b\'', (string) $argument, 'Dangerous names should be sanitized');
+    }
+
+    public function testFlagNameSanitizeControlCharacters()
+    {
+        $argument = new Flag("test\r\n");
+        $this->assertEquals(
+            '-test',
+            (string) $argument,
+            'Control characters should be stripped from names'
+        );
+    }
+
+    public function testFlagNameSanitizeControlCharactersUtf8()
+    {
+        $argument = new Flag("test\r\n\xE2\x80\xA8-\xD8\x9C2");
+        $this->assertEquals('-test-2', (string) $argument, 'Control characters should be stripped from names (UTF-8)');
+    }
+
+    public function testFlagNameSanitizeNonAsciiNonUtf8()
+    {
+        $argument = new Flag("t\xC4st\r\n");
+        $this->assertEquals(
+            '-tst',
+            (string) $argument,
+            'From non-UTF-8 name strings, all non-ascii characters should be stripped'
+        );
+    }
+
     public function testEmptyFlag()
     {
         $argument = new Flag('test');

--- a/tests/unit-tests/Command/SubCommandTest.php
+++ b/tests/unit-tests/Command/SubCommandTest.php
@@ -17,4 +17,52 @@ class SubCommandTest extends \PHPUnit_Framework_TestCase
         $command = new SubCommand('ls');
         $this->assertEquals('ls', (string) $command, 'SubCommand should cast to a string');
     }
+
+    public function testSimpleNoEscape()
+    {
+        $command = new SubCommand('do-some-stuff');
+        $this->assertEquals('do-some-stuff', (string)$command, 'SubCommand should not escape simple strings');
+    }
+
+    public function testDangerousEscape()
+    {
+        $command = new SubCommand('do-some-stuff --with-flags && rm /dev/null # comment stop');
+        $this->assertEquals(
+            'do-some-stuff\ --with-flags\ \&\&\ rm\ /dev/null\ \#\ comment\ stop',
+            (string)$command,
+            'SubCommand should create exactly one shell argument'
+        );
+    }
+
+    public function testAllowShellWildcards()
+    {
+        $command = new SubCommand('test stuff/{todo/*,.x??}');
+        $this->assertEquals('test\ stuff/{todo/*,.x??}', (string)$command, 'SubCommand should allow shell wild cards');
+    }
+
+    public function testControlCharactersRemoval()
+    {
+        $command = new SubCommand("do-\rsome\f-stuff\n");
+        $this->assertEquals('do-some-stuff', (string)$command, 'SubCommand should remove control characters');
+    }
+
+    public function testControlCharactersRemovalUtf8()
+    {
+        $command = new SubCommand("do\xE2\x80\xA8-\xD8\x9Cstuff\n");
+        $this->assertEquals(
+            'do-stuff',
+            (string)$command,
+            'SubCommand should remove unicode control characters from UTF-8 strings'
+        );
+    }
+
+    public function testControlCharactersRemovalNonAsciiNonUtf8()
+    {
+        $command = new SubCommand("T\xC4ST &&\r\nstop");
+        $this->assertEquals(
+            'TST\ \&\&stop',
+            (string)$command,
+            'SubCommand should remove all non-ascii characters from non-UTF-8 strings'
+        );
+    }
 }


### PR DESCRIPTION
Hi,

we would like to use your excellently designed shell wrapper, but are a bit concerned that injections cannot be completely ruled out if the average programmer is not aware that SubCommands and Arguments are not escaped at all.

Therefore, I would like to suggest the attached changes. The duplicate code in `SubCommand` and `Value` will be cleaned up, but I would like to hear your general opinion on this first.

Thanks & Best Regards
Ingmar
