### PR TITLE
Support object cloning and fix runner to be able to use them several times

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -74,9 +74,6 @@ class Command extends Command\AbstractCommand
         return $string;
     }
 
-    /**
-     * To clone internal command instance to avoid error
-     */
     public function __clone()
     {
         if ($this->command instanceof CommandInterface) {

--- a/src/Command.php
+++ b/src/Command.php
@@ -3,6 +3,8 @@
 namespace AdamBrett\ShellWrapper;
 
 use AdamBrett\ShellWrapper\Command\Argument;
+use AdamBrett\ShellWrapper\Command\Collections\Arguments;
+use AdamBrett\ShellWrapper\Command\CommandInterface;
 use AdamBrett\ShellWrapper\Command\Flag;
 use AdamBrett\ShellWrapper\Command\Param;
 use AdamBrett\ShellWrapper\Command\SubCommand;
@@ -70,5 +72,20 @@ class Command extends Command\AbstractCommand
         }
 
         return $string;
+    }
+
+    /**
+     * To clone internal command instance to avoid error
+     */
+    public function __clone()
+    {
+        if ($this->command instanceof CommandInterface) {
+            $this->command = clone $this->command;
+        }
+
+        $this->arguments = clone $this->arguments;
+        $this->flags = clone $this->flags;
+        $this->params = clone $this->params;
+        $this->subCommands = clone $this->subCommands;
     }
 }

--- a/src/Command/Collections/Flags.php
+++ b/src/Command/Collections/Flags.php
@@ -18,9 +18,6 @@ class Flags
         $this->flags[(string) $flag] = $flag;
     }
 
-    /**
-     * Clone each Flag object in the internal list
-     */
     public function __clone()
     {
         $clonedFlagsList = array();

--- a/src/Command/Collections/Flags.php
+++ b/src/Command/Collections/Flags.php
@@ -17,4 +17,17 @@ class Flags
     {
         $this->flags[(string) $flag] = $flag;
     }
+
+    /**
+     * Clone each Flag object in the internal list
+     */
+    public function __clone()
+    {
+        $clonedFlagsList = [];
+        foreach ($this->flags as $flag) {
+            $clonedFlagsList[] = clone $flag;
+        }
+
+        $this->flags = $clonedFlagsList;
+    }
 }

--- a/src/Command/Collections/Flags.php
+++ b/src/Command/Collections/Flags.php
@@ -23,7 +23,7 @@ class Flags
      */
     public function __clone()
     {
-        $clonedFlagsList = [];
+        $clonedFlagsList = array();
         foreach ($this->flags as $flag) {
             $clonedFlagsList[] = clone $flag;
         }

--- a/src/Command/Collections/Params.php
+++ b/src/Command/Collections/Params.php
@@ -13,11 +13,6 @@ class Params
         return join(' ', $this->params);
     }
 
-    public function addParam(Param $param)
-    {
-        $this->params[] = $param;
-    }
-
     /**
      * Clone each Params object in the internal list
      */
@@ -29,5 +24,10 @@ class Params
         }
 
         $this->params = $clonedParamsList;
+    }
+
+    public function addParam(Param $param)
+    {
+        $this->params[] = $param;
     }
 }

--- a/src/Command/Collections/Params.php
+++ b/src/Command/Collections/Params.php
@@ -23,7 +23,7 @@ class Params
      */
     public function __clone()
     {
-        $clonedParamsList = [];
+        $clonedParamsList = array();
         foreach ($this->params as $Param) {
             $clonedParamsList[] = clone $Param;
         }

--- a/src/Command/Collections/Params.php
+++ b/src/Command/Collections/Params.php
@@ -17,4 +17,17 @@ class Params
     {
         $this->params[] = $param;
     }
+
+    /**
+     * Clone each Params object in the internal list
+     */
+    public function __clone()
+    {
+        $clonedParamsList = [];
+        foreach ($this->params as $Param) {
+            $clonedParamsList[] = clone $Param;
+        }
+
+        $this->params = $clonedParamsList;
+    }
 }

--- a/src/Command/Collections/Params.php
+++ b/src/Command/Collections/Params.php
@@ -19,8 +19,8 @@ class Params
     public function __clone()
     {
         $clonedParamsList = array();
-        foreach ($this->params as $Param) {
-            $clonedParamsList[] = clone $Param;
+        foreach ($this->params as $param) {
+            $clonedParamsList[] = clone $param;
         }
 
         $this->params = $clonedParamsList;

--- a/src/Command/Collections/Params.php
+++ b/src/Command/Collections/Params.php
@@ -13,9 +13,6 @@ class Params
         return join(' ', $this->params);
     }
 
-    /**
-     * Clone each Params object in the internal list
-     */
     public function __clone()
     {
         $clonedParamsList = array();

--- a/src/Command/Collections/SubCommands.php
+++ b/src/Command/Collections/SubCommands.php
@@ -23,11 +23,11 @@ class SubCommands
      */
     public function __clone()
     {
-        $clonedSubCommandsList = array();
+        $subCommandsList = array();
         foreach ($this->subCommands as $subCommand) {
-            $clonedSubCommandsList[] = clone $subCommand;
+            $subCommandsList[] = clone $subCommand;
         }
 
-        $this->subCommands = $clonedSubCommandsList;
+        $this->subCommands = $subCommandsList;
     }
 }

--- a/src/Command/Collections/SubCommands.php
+++ b/src/Command/Collections/SubCommands.php
@@ -17,4 +17,17 @@ class SubCommands
     {
         $this->subCommands[] = $subCommand;
     }
+    
+    /**
+     * Clone each SubCommand object in the internal list
+     */
+    public function __clone()
+    {
+        $clonedSubCommandsList = [];
+        foreach ($this->subCommands as $subCommand) {
+            $clonedSubCommandsList[] = clone $subCommand;
+        }
+
+        $this->subCommands = $clonedSubCommandsList;
+    }
 }

--- a/src/Command/Collections/SubCommands.php
+++ b/src/Command/Collections/SubCommands.php
@@ -23,7 +23,7 @@ class SubCommands
      */
     public function __clone()
     {
-        $clonedSubCommandsList = [];
+        $clonedSubCommandsList = array();
         foreach ($this->subCommands as $subCommand) {
             $clonedSubCommandsList[] = clone $subCommand;
         }

--- a/src/Command/Collections/SubCommands.php
+++ b/src/Command/Collections/SubCommands.php
@@ -18,9 +18,6 @@ class SubCommands
         $this->subCommands[] = $subCommand;
     }
     
-    /**
-     * Clone each SubCommand object in the internal list
-     */
     public function __clone()
     {
         $subCommandsList = array();

--- a/src/Command/SubCommand.php
+++ b/src/Command/SubCommand.php
@@ -6,7 +6,7 @@ class SubCommand extends AbstractCommand
 {
     public function __toString()
     {
-        return $this->command;
+        return (string) $this->command;
     }
 
     /**

--- a/src/Command/SubCommand.php
+++ b/src/Command/SubCommand.php
@@ -8,4 +8,14 @@ class SubCommand extends AbstractCommand
     {
         return $this->command;
     }
+
+    /**
+     * To clone internal command instance to avoid error
+     */
+    public function __clone()
+    {
+        if ($this->command instanceof CommandInterface) {
+            $this->command = clone $this->command;
+        }
+    }
 }

--- a/src/Command/SubCommand.php
+++ b/src/Command/SubCommand.php
@@ -9,9 +9,6 @@ class SubCommand extends AbstractCommand
         return (string) $this->command;
     }
 
-    /**
-     * To clone internal command instance to avoid error
-     */
     public function __clone()
     {
         if ($this->command instanceof CommandInterface) {

--- a/src/Runners/Exec.php
+++ b/src/Runners/Exec.php
@@ -11,6 +11,8 @@ class Exec implements Runner, ReturnValue
 
     public function run(CommandInterface $command)
     {
+        $this->output = null;
+        $this->returnValue = null;
         return exec($command, $this->output, $this->returnValue);
     }
 

--- a/src/Runners/Passthru.php
+++ b/src/Runners/Passthru.php
@@ -10,6 +10,7 @@ class Passthru implements Runner, ReturnValue
 
     public function run(CommandInterface $command)
     {
+        $this->returnValue = null;
         return passthru((string) $command, $this->returnValue);
     }
 

--- a/src/Runners/System.php
+++ b/src/Runners/System.php
@@ -10,6 +10,7 @@ class System implements Runner, ReturnValue
 
     public function run(CommandInterface $command)
     {
+        $this->returnValue = null;
         return system((string) $command, $this->returnValue);
     }
 

--- a/tests/unit-tests/Command/Collections/ArgumentsTest.php
+++ b/tests/unit-tests/Command/Collections/ArgumentsTest.php
@@ -47,4 +47,17 @@ class ArgumentsTest extends \PHPUnit_Framework_TestCase
         $argumentList->addArgument(new Argument('test', 'value2'));
         $this->assertEquals("--test 'value2'", (string) $argumentList, 'ArgumentList should overwrite new values');
     }
+
+    public function testClone()
+    {
+        $argumentList1 = new ArgumentList();
+        $argumentList1->addArgument(new Argument('test', 'value'));
+
+        $argumentList2 = clone $argumentList1;
+        $argumentList2->addArgument(new Argument('test', 'value2'));
+        $argumentList2->addArgument(new Argument('test2', 'value'));
+
+        $this->assertEquals("--test 'value'", (string) $argumentList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals("--test 'value2' --test2 'value'", (string) $argumentList2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/Command/Collections/ArgumentsTest.php
+++ b/tests/unit-tests/Command/Collections/ArgumentsTest.php
@@ -57,7 +57,16 @@ class ArgumentsTest extends \PHPUnit_Framework_TestCase
         $argumentList2->addArgument(new Argument('test', 'value2'));
         $argumentList2->addArgument(new Argument('test2', 'value'));
 
-        $this->assertEquals("--test 'value'", (string) $argumentList1, 'Original collection must not be affect by cloned instances');
-        $this->assertEquals("--test 'value2' --test2 'value'", (string) $argumentList2, 'Cloned instances missing some options');
+        $this->assertEquals(
+            "--test 'value'",
+            (string) $argumentList1,
+            'Original collection must not be affect by cloned instances'
+        );
+
+        $this->assertEquals(
+            "--test 'value2' --test2 'value'",
+            (string) $argumentList2,
+            'Cloned instances missing some options'
+        );
     }
 }

--- a/tests/unit-tests/Command/Collections/FlagsTest.php
+++ b/tests/unit-tests/Command/Collections/FlagsTest.php
@@ -35,4 +35,16 @@ class FlagsTest extends \PHPUnit_Framework_TestCase
         $flagList->addFlag(new Flag('f'));
         $this->assertEquals('-f', (string) $flagList, 'FlagList should remove duplicates');
     }
+
+    public function testClone()
+    {
+        $flagList1 = new FlagList();
+        $flagList1->addFlag(new Flag('f'));
+
+        $flagList2 = clone $flagList1;
+        $flagList2->addFlag(new Flag('f'));
+
+        $this->assertEquals("-f", (string) $flagList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals("-f -f", (string) $flagList2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/Command/Collections/ParamsTest.php
+++ b/tests/unit-tests/Command/Collections/ParamsTest.php
@@ -35,4 +35,16 @@ class ParamsTest extends \PHPUnit_Framework_TestCase
         $paramList->addParam(new Param('test'));
         $this->assertEquals("'test' 'test'", (string) $paramList, 'ParamList should allow duplicates');
     }
+
+    public function testClone()
+    {
+        $paramList1 = new ParamList();
+        $paramList1->addParam(new Param('test'));
+
+        $paramList2 = clone $paramList1;
+        $paramList2->addParam(new Param('test'));
+
+        $this->assertEquals("'test'", (string) $paramList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals("'test' 'test'", (string) $paramList2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/Command/Collections/ParamsTest.php
+++ b/tests/unit-tests/Command/Collections/ParamsTest.php
@@ -44,7 +44,12 @@ class ParamsTest extends \PHPUnit_Framework_TestCase
         $paramList2 = clone $paramList1;
         $paramList2->addParam(new Param('test'));
 
-        $this->assertEquals("'test'", (string) $paramList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals(
+            "'test'",
+            (string) $paramList1,
+            'Original collection must not be affect by cloned instances'
+        );
+
         $this->assertEquals("'test' 'test'", (string) $paramList2, 'Cloned instances missing some options');
     }
 }

--- a/tests/unit-tests/Command/Collections/SubCommandsTest.php
+++ b/tests/unit-tests/Command/Collections/SubCommandsTest.php
@@ -35,4 +35,16 @@ class SubCommandsTest extends \PHPUnit_Framework_TestCase
         $subCommandList->addSubCommand(new SubCommand('test'));
         $this->assertEquals('test test', (string) $subCommandList, 'SubCommandList should allow duplicates');
     }
+
+    public function testClone()
+    {
+        $subCommandList1 = new SubCommandList();
+        $subCommandList1->addSubCommand(new SubCommand('test'));
+
+        $subCommandList2 = clone $subCommandList1;
+        $subCommandList2->addSubCommand(new SubCommand('test'));
+
+        $this->assertEquals('test', (string) $subCommandList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals('test test', (string) $subCommandList2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/Command/Collections/SubCommandsTest.php
+++ b/tests/unit-tests/Command/Collections/SubCommandsTest.php
@@ -44,7 +44,11 @@ class SubCommandsTest extends \PHPUnit_Framework_TestCase
         $subCommandList2 = clone $subCommandList1;
         $subCommandList2->addSubCommand(new SubCommand('test'));
 
-        $this->assertEquals('test', (string) $subCommandList1, 'Original collection must not be affect by cloned instances');
+        $this->assertEquals(
+            'test',
+            (string) $subCommandList1,
+            'Original collection must not be affect by cloned instances'
+        );
         $this->assertEquals('test test', (string) $subCommandList2, 'Cloned instances missing some options');
     }
 }

--- a/tests/unit-tests/Command/SubCommandTest.php
+++ b/tests/unit-tests/Command/SubCommandTest.php
@@ -17,4 +17,11 @@ class SubCommandTest extends \PHPUnit_Framework_TestCase
         $command = new SubCommand('ls');
         $this->assertEquals('ls', (string) $command, 'SubCommand should cast to a string');
     }
+
+    public function testClone()
+    {
+        $subCommand1 = new SubCommand('ls');
+        $subCommand2 = clone $subCommand1;
+        $this->assertEquals("ls", (string) $subCommand2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/Command/SubCommandTest.php
+++ b/tests/unit-tests/Command/SubCommandTest.php
@@ -20,7 +20,7 @@ class SubCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testClone()
     {
-        $subCommand1 = new SubCommand('ls');
+        $subCommand1 = new SubCommand(new SubCommand('ls'));
         $subCommand2 = clone $subCommand1;
         $this->assertEquals("ls", (string) $subCommand2, 'Cloned instances missing some options');
     }

--- a/tests/unit-tests/CommandTest.php
+++ b/tests/unit-tests/CommandTest.php
@@ -87,4 +87,24 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command->addParam(new Param('/var'));
         $this->assertEquals("ls '/srv' '/var'", (string) $command, 'Command should have multiple options');
     }
+
+    public function testClone()
+    {
+        $command1 = new Command('ls');
+        $command1->addParam(new Param('/srv'));
+        $command1->addSubCommand(new SubCommand('foo'));
+        $command1->addArgument(new Argument('h'));
+
+        $command2 = clone $command1;
+        $command2->addParam(new Param('/var'));
+        $command2->addSubCommand(new SubCommand('bar'));
+        $command2->addArgument(new Argument('a'));
+
+        $this->assertEquals("ls foo --h '/srv'", (string) $command1, 'Original command must not be affect by cloned instances');
+        $this->assertEquals("ls foo bar --h --a '/srv' '/var'", (string) $command2, 'Cloned instances missing some options');
+
+        $command1 = new Command(new Command('ls'));
+        $command2 = clone $command1;
+        $this->assertEquals("ls", (string) $command2, 'Cloned instances missing some options');
+    }
 }

--- a/tests/unit-tests/CommandTest.php
+++ b/tests/unit-tests/CommandTest.php
@@ -100,8 +100,17 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command2->addSubCommand(new SubCommand('bar'));
         $command2->addArgument(new Argument('a'));
 
-        $this->assertEquals("ls foo --h '/srv'", (string) $command1, 'Original command must not be affect by cloned instances');
-        $this->assertEquals("ls foo bar --h --a '/srv' '/var'", (string) $command2, 'Cloned instances missing some options');
+        $this->assertEquals(
+            "ls foo --h '/srv'",
+            (string) $command1,
+            'Original command must not be affect by cloned instances'
+        );
+
+        $this->assertEquals(
+            "ls foo bar --h --a '/srv' '/var'",
+            (string) $command2,
+            'Cloned instances missing some options'
+        );
 
         $command1 = new Command(new Command('ls'));
         $command2 = clone $command1;

--- a/tests/unit-tests/ExitCodesTest.php
+++ b/tests/unit-tests/ExitCodesTest.php
@@ -19,6 +19,31 @@ class ExitCodesTest extends \PHPUnit_Framework_TestCase
             ExitCodes::getDescription(ExitCodes::SUCCESS),
             'A string should be returned'
         );
+        $this->assertInternalType(
+            'string',
+            ExitCodes::getDescription(ExitCodes::GENERAL_ERROR),
+            'A string should be returned'
+        );
+        $this->assertInternalType(
+            'string',
+            ExitCodes::getDescription(ExitCodes::BUILTIN_MISUSE),
+            'A string should be returned'
+        );
+        $this->assertInternalType(
+            'string',
+            ExitCodes::getDescription(ExitCodes::PERMISSION_ERROR),
+            'A string should be returned'
+        );
+        $this->assertInternalType(
+            'string',
+            ExitCodes::getDescription(ExitCodes::COMMAND_NOT_FOUND),
+            'A string should be returned'
+        );
+        $this->assertInternalType(
+            'string',
+            ExitCodes::getDescription(ExitCodes::USER_TERMINATED),
+            'A string should be returned'
+        );
     }
 
     public function test3To125AreUnknownOrCustom()


### PR DESCRIPTION
In PHP, objects cloning does not clone objects inside the cloned object ( http://php.net/manual/en/language.oop5.cloning.php )

So, operations on $command2  (with $command2 = clone $command1) affect also $command1.

This pull request adds support of deep cloning.
Fix another issue to use some runner several times (else, firsts outputs are append to next output).